### PR TITLE
Fix/update ruby version for ci and remove mfa for gem upload

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@main
 
-      - name: Set up Ruby 2.7
+      - name: Set up Ruby 3.2.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2.2
 
       - name: Get version
         id: get_version

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,8 +46,6 @@ Metrics/PerceivedComplexity:
   Enabled: false
 
 # Naming cop configuration
-#Naming/FileName:
-#  Enabled: false
 Naming/MethodParameterName:
   Enabled: true
   Exclude:
@@ -122,4 +120,8 @@ Style/NumericPredicate:
 Style/RedundantSelf:
   Enabled: true
 Style/RescueStandardError:
+  Enabled: false
+
+# Gem Spec cop configuration
+Gemspec/RequireMFA:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.1]
+
+- Build Gem with ruby 3.2.2 and remove mfa for gem publishing CD
+
 ## [1.1.0]
 
 - Update ruby version, add CI, rubocop autocorrect

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-azure-devops (1.1.0)
+    omniauth-azure-devops (1.1.1)
       omniauth (>= 1, < 3)
       omniauth-oauth2
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     omniauth-azure-devops (1.1.1)
       omniauth (>= 1, < 3)
-      omniauth-oauth2
+      omniauth-oauth2 (~> 1.8.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/omni_auth/azure_devops/version.rb
+++ b/lib/omni_auth/azure_devops/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module AzureDevops
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end

--- a/omniauth-azure-devops.gemspec
+++ b/omniauth-azure-devops.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/rewind/omniauth-azure-devops'
   gem.license       = 'MIT'
   gem.metadata = {
-    'rubygems_mfa_required' => 'true',
+    'rubygems_mfa_required' => 'false',
     'bug_tracker_uri' => "#{gem.homepage}/issues",
     'changelog_uri' => "#{gem.homepage}/blob/main/CHANGELOG.md",
     'documentation_uri' => gem.homepage.to_s,

--- a/omniauth-azure-devops.gemspec
+++ b/omniauth-azure-devops.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 3.2'
 
   gem.add_runtime_dependency 'omniauth', '>= 1', '< 3'
-  gem.add_runtime_dependency 'omniauth-oauth2'
+  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.8.0'
 end


### PR DESCRIPTION
## Description of Change
- Update the CI to use ruby 3.2.2 to pack the Gem
- Remove mfa to publish the gem
- Bump up the version