### PR TITLE
Revert "fix(): Use common tag-and-release workflow (#16)"

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -4,13 +4,68 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'lib/**/version.rb'
+    paths: 'lib/**/version.rb'
 
 jobs:
   release:
-    uses: rewindio/github-action-common/.github/workflows/tag-and-release.yml@v1
-    with:
-      registry: rubygems
-    secrets:
-      REGISTRY_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Set up Ruby 3.2.2
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+
+      - name: Get version
+        id: get_version
+        run: |
+          version_file=$(find ./lib -name version.rb)
+          version=$(grep VERSION $version_file |cut -f 2 -d= |tr -d \'|tr -d [:space:])
+          echo version=$version >> $GITHUB_OUTPUT
+          echo version_tag=v$version >> $GITHUB_OUTPUT
+
+      - name: Tag commit
+        uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{steps.get_version.outputs.version_tag}}"
+
+      - name: Upload to Rubygems
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
+          set +e
+          mkdir -p ~/.gem
+          touch ~/.gem/credentials
+          chmod 600 ~/.gem/credentials
+          echo ":rubygems_api_key: ${RUBYGEMS_API_KEY}" >> ~/.gem/credentials
+          
+          gemspec=$(ls *gemspec* | head -1)
+          gem build $gemspec
+          gem_name=$(ls -t *.gem | head -1)
+          output=$(gem push *.gem)
+          
+          if [[ $output != *"Successfully"* ]]; then
+            echo "Error uploading to Rubygems: $output"
+            rm -f ~/.gem/credentials
+            exit 1
+          else
+            echo "Successfully uploaded to Rubygems: $output"
+            rm -f ~/.gem/credentials
+          fi
+
+      - name: Extract from changelog
+        id: extract_changes
+        run: |
+          # Must use a temporary file or it loses the formatting
+          VERSION=${{steps.get_version.outputs.version}}; awk "/## \[$VERSION\]/{flag=1;next}/## \[/{flag=0}flag" CHANGELOG.md > REL-BODY.md
+
+      - name: Create Release
+        uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0
+        with:
+          tag: ${{steps.get_version.outputs.version_tag}}
+          artifacts: "*.gem, CHANGELOG.md"
+          bodyFile: "REL-BODY.md"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
 # Changelog
-## [1.0.3]
-
-- Validate new tag and release workflow
 
 ## [1.0.2]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-azure-devops (1.0.3)
+    omniauth-azure-devops (1.0.2)
       omniauth (>= 1, < 3)
       omniauth-oauth2 (~> 1.1)
 

--- a/lib/omni_auth/azure_devops/version.rb
+++ b/lib/omni_auth/azure_devops/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module AzureDevops
-    VERSION = '1.0.3'
+    VERSION = '1.0.2'
   end
 end


### PR DESCRIPTION
This reverts commit 8e89b05ae824bbfb8de140fa617f1fa3b7913680.

## Description of Change
This is a public repo. We can't use reusable flows here.

### NOTE: The version release to 1.0.3 did not go forward.