### PR TITLE
chore(): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "appsec"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "patch"
+        - "minor"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Get version
         id: get_version
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
         with:
           ruby-version: 3.4.5
 

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
 
       - name: Set up Ruby 3.4.5
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
         with:
           ruby-version: 3.4.5
 
@@ -41,12 +41,12 @@ jobs:
           touch ~/.gem/credentials
           chmod 600 ~/.gem/credentials
           echo ":rubygems_api_key: ${RUBYGEMS_API_KEY}" >> ~/.gem/credentials
-          
+
           gemspec=$(ls *gemspec* | head -1)
           gem build $gemspec
           gem_name=$(ls -t *.gem | head -1)
           output=$(gem push *.gem)
-          
+
           if [[ $output != *"Successfully"* ]]; then
             echo "Error uploading to Rubygems: $output"
             rm -f ~/.gem/credentials

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,40 +7,40 @@ jobs:
     name: rspec tests
     runs-on: ubuntu-latest
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.4.5
-        bundler-cache: true
+      - name: Install Ruby
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
+        with:
+          ruby-version: 3.4.5
+          bundler-cache: true
 
-    - name: Run rspec tests
-      run: |
-        bundle exec rspec
+      - name: Run rspec tests
+        run: |
+          bundle exec rspec
 
 
-    - name: Upload coverage results
-      uses: actions/upload-artifact@v4
-      with:
-        include-hidden-files: 'true'
-        name: coverage-results
-        path: coverage
-        retention-days: 5
+      - name: Upload coverage results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          include-hidden-files: 'true'
+          name: coverage-results
+          path: coverage
+          retention-days: 5
   coverage:
     needs: rspec
     runs-on: ubuntu-latest
     steps:
-    - name: Download coverage results
-      uses: actions/download-artifact@v4
-      with:
-        name: coverage-results
-        path: coverage
+      - name: Download coverage results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: coverage-results
+          path: coverage
 
-    - name: Simplecov Report
-      uses: aki77/simplecov-report-action@7fd5fa551dd583dd437a11c640b2a1cf23d6cdaa   # v1.5.2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        failedThreshold: 100
-        resultPath: coverage/.last_run.json
+      - name: Simplecov Report
+        uses: aki77/simplecov-report-action@7fd5fa551dd583dd437a11c640b2a1cf23d6cdaa # v1.5.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          failedThreshold: 100
+          resultPath: coverage/.last_run.json


### PR DESCRIPTION
# Pin GitHub Actions to commit SHAs

## Description of change

Pins all third-party GitHub Actions to specific commit SHAs to protect
against tag hijacking / supply chain attacks. Actions from the `rewindio`
org are excluded and remain at their original version refs.

Uses [ratchet](https://github.com/sethvargo/ratchet) for SHA resolution.

## Testing Performed
