### PR TITLE
fix(): Change CODEOWNERs to integration squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Parth-Rewind @calvinc03-rewind @lais-rewind @evansalter @julesclay @PatrickBaciu
+* @rewindio/integration-squad


### PR DESCRIPTION
## Description of Changes

As `@julesclay` is no longer with us (rip) both as an employee, and as a Github User, it leaves the repo open to malicious swooping in and self-approval of PRs.

Safer than adding and removing individual users from the Codeowners list is simply adding a team.

If you check out the @julesclay user you will see the BugCrowd researcher who reported this. 