### PR TITLE
chore: update CODEOWNERS team ref and fix coverage job permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rewindio/integration-squad
+* @rewind-community/developers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,9 @@ jobs:
   coverage:
     needs: rspec
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Download coverage results
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
# **Jira:** [DEVOPS-4349](https://rewind.atlassian.net/browse/DEVOPS-4349)

## Description of Change

This repo was moved from `rewindio` to `rewind-community` as part of the OSS-repo classification cleanup (terraform side: rewindio/terraform-rewindio-github#366). The existing `@rewindio/integration-squad` reference is silently dropped by GitHub because team references can't cross organizations.

`integration-squad` does **not** exist in `rewind-community` (the org has `admins`, `appsec`, `deploy`, `developers`, `devops`). Reassigning to `@rewind-community/developers` because this is a Ruby OAuth strategy gem — general developer review fits the engagement model better than a specialized team. If a more specific team gets added to `rewind-community` later, this can be updated.

While testing this PR, the `coverage` job in `.github/workflows/tests.yml` started failing with "Resource not accessible by integration". The org-default `GITHUB_TOKEN` permissions in `rewind-community` are read-only, and `simplecov-report-action` posts a coverage comment back to the PR — which requires `pull-requests: write`. This was masked under `rewindio` because that org granted broader defaults. Adding a per-job `permissions:` block fixes the failure without widening scope beyond what the coverage step actually needs.

## Related PRs

- rewindio/terraform-rewindio-github#366

## Testing Performed

CODEOWNERS change: single-line edit, no code paths affected. GitHub will pick up the new team reference on the next PR review request.

Workflow permissions change: verified by re-running CI on this branch — both \`rspec tests\` (12s) and \`coverage\` (8s) jobs pass, and the Simplecov Report step now completes without a 403 (run [26306601164](https://github.com/rewind-community/omniauth-azure-devops/actions/runs/26306601164)).

[DEVOPS-4349]: https://rewind.atlassian.net/browse/DEVOPS-4349