### PR TITLE
fix(PE-10282): update oauth2 to 2.0.25 to resolve CVE-2026-54603

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.6]
+
+- Resolve CVE-2026-54603 by updating oauth2 to 2.0.25
+
 ## [1.0.5]
 
 - Update Ruby version to 3.4.5 to address security vulnerabilities

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,19 @@
 PATH
   remote: .
   specs:
-    omniauth-azure-devops (1.0.5)
+    omniauth-azure-devops (1.0.6)
       omniauth (>= 1, < 3)
       omniauth-oauth2 (~> 1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    anonymous_loader (0.1.3)
+      version_gem (~> 1.1, >= 1.1.14)
     ansi (1.5.0)
     ast (2.4.3)
+    auth-sanitizer (0.2.3)
+      version_gem (~> 1.1, >= 1.1.14)
     base64 (0.3.0)
     bigdecimal (3.2.2)
     coderay (1.1.3)
@@ -33,14 +37,16 @@ GEM
       bigdecimal (~> 3.1)
     net-http (0.6.0)
       uri
-    oauth2 (2.0.12)
+    oauth2 (2.0.25)
+      anonymous_loader (~> 0.1, >= 0.1.3)
+      auth-sanitizer (~> 0.2, >= 0.2.3)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.3)
-      version_gem (>= 1.1.8, < 3)
+      snaky_hash (~> 2.0, >= 2.0.7)
+      version_gem (~> 1.1, >= 1.1.14)
     omniauth (2.1.3)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -110,16 +116,16 @@ GEM
       terminal-table
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
-    snaky_hash (2.0.3)
+    snaky_hash (2.0.7)
       hashie (>= 0.1.0, < 6)
-      version_gem (>= 1.1.8, < 3)
+      version_gem (~> 1.1, >= 1.1.14)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     uri (1.0.3)
-    version_gem (1.1.8)
+    version_gem (1.1.15)
 
 PLATFORMS
   ruby

--- a/lib/omni_auth/azure_devops/version.rb
+++ b/lib/omni_auth/azure_devops/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module AzureDevops
-    VERSION = '1.0.5'
+    VERSION = '1.0.6'
   end
 end


### PR DESCRIPTION
## Problem

`oauth2 <= 2.0.21` leaks the caller's bearer token to an attacker-controlled host.

`OAuth2::Client#request` resolved a redirect's `Location` header with `response.response.env.url.merge(location)`. Per RFC 3986 §5.2 an input starting with `//` is a *network-path reference*, so `URI("http://idp.trusted/userinfo").merge("//attacker.example/leak")` returns `http://attacker.example/leak` — the base authority is replaced. The recursive retry then re-sent the request to the attacker's host with the `Authorization: Bearer <token>` header still attached by `AccessToken#configure_authentication!`.

One influenced 30x response is enough — no second user interaction, no redirect chain, and the `//` form slips past naive scheme-based `Location` filters. It doubles as an SSRF primitive (`//169.254.169.254/...`).

This lockfile pinned `oauth2 2.0.12`, which is vulnerable. Bumped to `2.0.25`, which resolves protocol-relative locations against the original authority *and* strips `Authorization` headers on cross-origin redirects (the defence-in-depth follow-up the advisory recommended).

- Advisory: [GHSA-pp92-crg2-gfv9](https://github.com/advisories/GHSA-pp92-crg2-gfv9) / CVE-2026-54603 (CVSS 8.6, patched in 2.0.22)
- `oauth2` arrives transitively via `omniauth-oauth2 (~> 1.1)` → `oauth2 (>= 1.4, < 3)`. No gemspec change is needed: the existing constraint already admits the patched version, so this is a lockfile bump plus the release plumbing this repo uses for CVE fixes.

> [!IMPORTANT]
> Merging this bumps `lib/omni_auth/azure_devops/version.rb`, which triggers `tag-and-release.yml` on `main` — it will tag `v1.0.6`, publish the gem to RubyGems, and cut a GitHub release from the `## [1.0.6]` CHANGELOG section. That is the intended outcome (consumers only pick up the fix via a released version), but it means this merge is a publish.

## Related PRs

Same CVE, fixed in parallel across the affected repos:

- rewind-community/omniauth-miro#37
- rewindio/rewind-admin#2617 (PE-10264)

## Jira

[PE-10282](https://rewind.atlassian.net/browse/PE-10282)

## Testing Performed

- [x] `bundle exec rspec` — 15 examples, 0 failures, 100% line coverage (CI's `failedThreshold: 100`)
- [x] `bundle exec rubocop` — 1 offense, `Naming/FileName` on `lib/omniauth-azure-devops.rb`, pre-existing on `main` and untouched here; CI's reviewdog runs `filter_mode: file` so it won't be reported
- [x] Confirmed the resolved tree moves `oauth2 2.0.12 -> 2.0.25`; `BUNDLED WITH` deliberately left at `2.4.19` so the diff stays security-only
- [x] Reproduced the exploit end-to-end against a local IdP that answers `302` with `Location: //127.0.0.1:4568/leak`, with a collector on `:4568`:
  ```
  oauth2 2.0.12  -> [attacker] GET /leak  auth="Bearer SECRET-BEARER-XYZZY"   FAIL (leaked)
  oauth2 2.0.25  -> collector received 0 requests; all 6 hops stayed on the IdP   PASS
  ```
- [x] Verified `2.0.25` ships both `resolve_redirect_location` (protocol-relative handling) and `sanitize_redirect_options` (strips `Authorization` cross-origin)

---
Created-With-Skill: create-pr
