### PR TITLE
fix(ci): tag and release via rewind-community-tagger app token

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
 
@@ -26,10 +29,17 @@ jobs:
           echo version=$version >> $GITHUB_OUTPUT
           echo version_tag=v$version >> $GITHUB_OUTPUT
 
+      - name: Create tagger app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.TAGGER_APP_ID }}
+          private-key: ${{ secrets.TAGGER_PRIVATE_KEY }}
+
       - name: Tag commit
         uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: "${{ steps.app-token.outputs.token }}"
           tag: "${{steps.get_version.outputs.version_tag}}"
 
       - name: Upload to Rubygems
@@ -68,4 +78,4 @@ jobs:
           tag: ${{steps.get_version.outputs.version_tag}}
           artifacts: "*.gem, CHANGELOG.md"
           bodyFile: "REL-BODY.md"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Why

The `tag-and-release` run for **v1.0.6** failed at the `Tag commit` step with `HttpError: Resource not accessible by integration` ([run 31500836484](https://github.com/rewind-community/omniauth-azure-devops/actions/runs/31500836484)). The trigger was #42 bumping `VERSION` to `1.0.6` — the first `lib/**/version.rb` change since 2025-08-07, so this was the first time the workflow ran since the org tightened its Actions defaults and the repo moved to `rewind-community`.

There are **two** separate barriers in front of `GITHUB_TOKEN`, and fixing only the first one is not enough.

**1. The token is read-only.** The workflow declared no `permissions:` block, so it inherited the repo default (`default_workflow_permissions: read`). The tagger action's only operation is `git.createRef` → `POST /git/refs`, which requires `contents: write`. Hence the 403.

**2. `contents: write` alone would still fail.** The org-level ruleset `rewind-tag` is `active` over `~ALL` tags and carries a `creation` rule, restricting tag creation to two bypass actors: `OrganizationAdmin` and the `rewind-community-tagger` App. `GITHUB_TOKEN` is neither, so it would get past the permission check and then be rejected by the ruleset with `Reference update failed`.

This isn't speculation — `eight_ball` already ran the experiment:

| Run | Change | Result |
|---|---|---|
| [29513619634](https://github.com/rewind-community/eight_ball/actions/runs/29513619634) | grant `contents: write` | ❌ `Reference update failed` |
| [29515788879](https://github.com/rewind-community/eight_ball/actions/runs/29515788879) | use tagger app token | ✅ success |

## What

Mint a `rewind-community-tagger` installation token and use it for both `Tag commit` and `Create Release`. `ncipollo/release-action` also needs `contents: write` and creates the tag when it's absent, so it hits the same ruleset — both steps have to move to the app token. `GITHUB_TOKEN` is now pinned explicitly to `contents: read`.

This matches the pattern already proven in `eight_ball`.

Notes on the details:

- The app is installed org-wide (`repository_selection: all`) and holds `contents: write`, so no per-repo install is needed here.
- `TAGGER_APP_ID` and `TAGGER_PRIVATE_KEY` are existing org secrets, already confirmed visible to this repo.
- `create-github-app-token` is pinned to the `v3` tag SHA, which resolves to release **3.2.0** — the latest stable (2026-05-12) and the same pin `eight_ball` uses, so "latest stable" and "consistent with the org" agree.

## ⚠️ Merging this does not release v1.0.6

The workflow only triggers on `paths: 'lib/**/version.rb'`, and this PR touches only the workflow file — so no release run will fire on merge. Re-running the failed run won't help either: `push`-event re-runs use the workflow file from the original commit, which still has the old token.

Two ways to actually ship the v1.0.6 CVE fix, your call:

1. **Bump to 1.0.7** in a follow-up (add a CHANGELOG entry). This is what `eight_ball` did — it folded the fix and a version bump into one PR. `1.0.6` becomes a phantom version, never tagged or published.
2. **Add `workflow_dispatch`** to the workflow so `v1.0.6` can be released manually, as originally intended.

I stopped short of choosing, since it changes the version number consumers see.

## Test plan

- [x] YAML parses (Ruby psych); `permissions` is `{contents: read}`
- [x] `Create tagger app token` step ordered before `Tag commit`
- [x] Both `repo-token` and `token` resolve to `steps.app-token.outputs.token`; no `secrets.GITHUB_TOKEN` left in this workflow
- [x] Tagger app installed on this repo (`repository_selection: all`) with `contents: write`, and present in the `rewind-tag` bypass actors
- [x] Release state clean before merge — no `v1.0.6` tag, no `v1.0.6` release, RubyGems latest is `1.0.5`, `Upload to Rubygems` never ran (nothing partially published)
- [ ] End-to-end confirmation on the next version bump (see the section above)

## Also worth knowing

Four sibling repos carry the identical latent break — same tagger action, no `permissions:` block, repo default `read`: `aws-connect`, `dagwood`, `github-repo-secrets-manager`, `omniauth-miro`. Each will fail the same way on its next `version.rb` bump. Not touched here; happy to do them in a follow-up pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)