### PR TITLE
fix(): Release 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.7]
+
+- Fix the `tag-and-release` workflow to create the release tag with the `rewind-community-tagger` GitHub App token (`TAGGER_APP_ID`/`TAGGER_PRIVATE_KEY`) instead of the default `GITHUB_TOKEN`
+
 ## [1.0.6]
 
 - Resolve CVE-2026-54603 by updating oauth2 to 2.0.25

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-azure-devops (1.0.6)
+    omniauth-azure-devops (1.0.7)
       omniauth (>= 1, < 3)
       omniauth-oauth2 (~> 1.1)
 

--- a/lib/omni_auth/azure_devops/version.rb
+++ b/lib/omni_auth/azure_devops/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module AzureDevops
-    VERSION = '1.0.6'
+    VERSION = '1.0.7'
   end
 end


### PR DESCRIPTION
`1.0.6` did not release successfully (ref https://github.com/rewind-community/omniauth-azure-devops/pull/42) and the fix did not trigger a new release (ref https://github.com/rewind-community/omniauth-azure-devops/pull/43). Looking to release `1.0.7` which captures the unreleased changes and the fix to the tag and release action.